### PR TITLE
Expose a copy of list store values to parent lists store

### DIFF
--- a/client/app/(index)/_layout.tsx
+++ b/client/app/(index)/_layout.tsx
@@ -6,9 +6,9 @@ import { Provider as TinyBaseProvider } from "tinybase/ui-react";
 import { Inspector } from "tinybase/ui-react-inspector";
 import { Button } from "@/components/ui/button";
 import { ListCreationProvider } from "@/context/ListCreationContext";
+import { WidgetProvider } from "@/contexts/WidgetContext";
 import ShoppingListsStore from "@/stores/ShoppingListsStore";
 import { SignedIn, useUser } from "@clerk/clerk-expo";
-import { WidgetProvider } from "@/contexts/WidgetContext";
 
 export const unstable_settings = {
   initialRouteName: "index",

--- a/client/app/(index)/list/new/index.tsx
+++ b/client/app/(index)/list/new/index.tsx
@@ -1,10 +1,5 @@
 import React, { useMemo, useState } from "react";
-import {
-  Href,
-  useGlobalSearchParams,
-  usePathname,
-  useRouter,
-} from "expo-router";
+import { Href, useGlobalSearchParams, useRouter } from "expo-router";
 import { StyleSheet, View } from "react-native";
 // Components
 import { IconCircle } from "@/components/IconCircle";

--- a/client/app/(index)/profile.tsx
+++ b/client/app/(index)/profile.tsx
@@ -1,22 +1,22 @@
-import * as Updates from "expo-updates";
+import { useEffect } from "react";
 import * as Application from "expo-application";
 import { useRouter } from "expo-router";
+import * as Updates from "expo-updates";
 import {
   Alert,
   Image,
-  View,
-  StyleSheet,
-  Share,
-  Pressable,
   Linking,
+  Pressable,
+  Share,
+  StyleSheet,
+  View,
 } from "react-native";
 import { ThemedText } from "@/components/ThemedText";
 import { BodyScrollView } from "@/components/ui/BodyScrollView";
 import Button from "@/components/ui/button";
+import { IconSymbol } from "@/components/ui/IconSymbol";
 import { appleBlue, appleGreen, appleRed } from "@/constants/Colors";
 import { useClerk, useUser } from "@clerk/clerk-expo";
-import { useEffect } from "react";
-import { IconSymbol } from "@/components/ui/IconSymbol";
 
 export default function ProfileScreen() {
   const { user } = useUser();

--- a/client/app/_layout.tsx
+++ b/client/app/_layout.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 import { useFonts } from "expo-font";
 import { Slot } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
+import { SystemBars } from "react-native-edge-to-edge";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { tokenCache } from "@/cache";
 import { useColorScheme } from "@/hooks/useColorScheme";
@@ -13,7 +14,6 @@ import {
   Theme,
   ThemeProvider,
 } from "@react-navigation/native";
-import { SystemBars } from "react-native-edge-to-edge";
 
 const publishableKey = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY!;
 

--- a/client/components/ShoppingListItem.tsx
+++ b/client/components/ShoppingListItem.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import * as Haptics from "expo-haptics";
 import { Link } from "expo-router";
-import { Pressable, StyleSheet, View, useColorScheme } from "react-native";
+import { Pressable, StyleSheet, useColorScheme, View } from "react-native";
 import ReanimatedSwipeable from "react-native-gesture-handler/ReanimatedSwipeable";
 import Animated, {
   configureReanimatedLogger,

--- a/client/contexts/WidgetContext.tsx
+++ b/client/contexts/WidgetContext.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 import { createContext, useCallback, useContext } from "react";
 import {
-  useRecentShoppingLists,
   useShoppingListIds,
+  useShoppingListsValues,
 } from "@/stores/ShoppingListsStore";
 import { ExtensionStorage } from "@bacons/apple-targets";
 
@@ -18,7 +18,7 @@ type WidgetContextType = {
 const WidgetContext = createContext<WidgetContextType | null>(null);
 
 export function WidgetProvider({ children }: { children: React.ReactNode }) {
-  const recentLists = useRecentShoppingLists();
+  const recentLists = useShoppingListsValues();
   const shoppingListIds = useShoppingListIds();
   // console.log("recentLists", recentLists.length);
   console.log("recentLists", recentLists);

--- a/client/contexts/WidgetContext.tsx
+++ b/client/contexts/WidgetContext.tsx
@@ -1,12 +1,10 @@
 import * as React from "react";
-import { createContext, useContext, useCallback } from "react";
-import { ExtensionStorage } from "@bacons/apple-targets";
-import { useStore } from "tinybase/ui-react";
+import { createContext, useCallback, useContext } from "react";
 import {
   useRecentShoppingLists,
   useShoppingListIds,
 } from "@/stores/ShoppingListsStore";
-import { useShoppingListValue } from "@/stores/ShoppingListStore";
+import { ExtensionStorage } from "@bacons/apple-targets";
 
 // Initialize storage with your group ID
 const storage = new ExtensionStorage(

--- a/client/stores/ShoppingListStore.tsx
+++ b/client/stores/ShoppingListStore.tsx
@@ -10,7 +10,6 @@ import {
 } from "tinybase/with-schemas";
 import { useUserIdAndNickname } from "@/hooks/useNickname";
 import { useCreateClientPersisterAndStart } from "@/stores/persistence/useCreateClientPersisterAndStart";
-import { useValuesCopy } from "./ShoppingListsStore";
 import { useCreateServerSynchronizerAndStart } from "./synchronization/useCreateServerSynchronizerAndStart";
 
 const STORE_ID_PREFIX = "shoppingListStore-";
@@ -176,7 +175,13 @@ export const useShoppingListUserNicknames = (listId: string) =>
   );
 
 // Create, persist, and sync a store containing the shopping list and products.
-export default function ShoppingListStore({ listId }: { listId: string }) {
+export default function ShoppingListStore({
+  listId,
+  useValuesCopy,
+}: {
+  listId: string;
+  useValuesCopy: (id: string) => [string, (valuesCopy: string) => void];
+}) {
   const storeId = useStoreId(listId);
   const [userId, nickname] = useUserIdAndNickname();
   const [valuesCopy, setValuesCopy] = useValuesCopy(listId);

--- a/client/stores/ShoppingListStore.tsx
+++ b/client/stores/ShoppingListStore.tsx
@@ -176,16 +176,10 @@ export const useShoppingListUserNicknames = (listId: string) =>
   );
 
 // Create, persist, and sync a store containing the shopping list and products.
-export default function ShoppingListStore({
-  listId,
-  initialContentJson,
-}: {
-  listId: string;
-  initialContentJson: string;
-}) {
+export default function ShoppingListStore({ listId }: { listId: string }) {
   const storeId = useStoreId(listId);
   const [userId, nickname] = useUserIdAndNickname();
-  const [, setValuesCopy] = useValuesCopy(listId);
+  const [valuesCopy, setValuesCopy] = useValuesCopy(listId);
 
   const store = useCreateMergeableStore(() =>
     createMergeableStore().setSchema(TABLES_SCHEMA, VALUES_SCHEMA)
@@ -201,7 +195,7 @@ export default function ShoppingListStore({
 
   // Persist store (with initial content if it hasn't been saved before), then
   // ensure the current user is added as a collaborator.
-  useCreateClientPersisterAndStart(storeId, store, initialContentJson, () =>
+  useCreateClientPersisterAndStart(storeId, store, valuesCopy, () =>
     store.setRow("collaborators", userId, { nickname })
   );
   useCreateServerSynchronizerAndStart(storeId, store);

--- a/client/stores/ShoppingListsStore.tsx
+++ b/client/stores/ShoppingListsStore.tsx
@@ -13,14 +13,17 @@ const TABLES_SCHEMA = {
   lists: {
     id: { type: "string" },
     initialContentJson: { type: "string" },
+    valuesCopy: { type: "string" },
   },
 } as const;
 
 const {
+  useCell,
   useCreateMergeableStore,
   useDelRowCallback,
   useProvideStore,
   useRowIds,
+  useSetCellCallback,
   useStore,
   useTable,
 } = UiReact as UiReact.WithSchemas<[typeof TABLES_SCHEMA, NoValuesSchema]>;
@@ -67,6 +70,20 @@ export const useJoinShoppingListCallback = () => {
     [store]
   );
 };
+
+export const useValuesCopy = (
+  id: string
+): [string, (valuesCopy: string) => void] => [
+  useCell("lists", id, "valuesCopy", useStoreId()),
+  useSetCellCallback(
+    "lists",
+    id,
+    "valuesCopy",
+    (valuesCopy: string) => valuesCopy,
+    [],
+    useStoreId()
+  ),
+];
 
 // Returns a callback that deletes a shopping list from the store.
 export const useDelShoppingListCallback = (id: string) =>

--- a/client/stores/ShoppingListsStore.tsx
+++ b/client/stores/ShoppingListsStore.tsx
@@ -12,7 +12,6 @@ const STORE_ID_PREFIX = "shoppingListsStore-";
 const TABLES_SCHEMA = {
   lists: {
     id: { type: "string" },
-    initialContentJson: { type: "string" },
     valuesCopy: { type: "string" },
   },
 } as const;
@@ -38,18 +37,15 @@ export const useAddShoppingListCallback = () => {
       const id = randomUUID();
       store.setRow("lists", id, {
         id,
-        initialContentJson: JSON.stringify([
-          {},
-          {
-            id,
-            name,
-            description,
-            emoji,
-            color,
-            createdAt: new Date().toISOString(),
-            updatedAt: new Date().toISOString(),
-          },
-        ]),
+        valuesCopy: JSON.stringify({
+          id,
+          name,
+          description,
+          emoji,
+          color,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        }),
       });
       return id;
     },
@@ -64,7 +60,7 @@ export const useJoinShoppingListCallback = () => {
     (listId: string) => {
       store.setRow("lists", listId, {
         id: listId,
-        initialContentJson: JSON.stringify([{}, {}]),
+        valuesCopy: "{}",
       });
     },
     [store]
@@ -101,17 +97,7 @@ export const useRecentShoppingLists = () => {
   const recentListIds = listIds.slice(0, 10);
 
   return recentListIds.map((listId) => {
-    const initialContentJson = store.getRow(
-      "lists",
-      listId
-    )?.initialContentJson;
-    const [, metadata] = JSON.parse(initialContentJson || "[{},{}]");
-
-    return {
-      listId,
-      name: metadata?.name || "",
-      emoji: metadata?.emoji || "",
-    };
+    return store.getRow("lists", listId)?.valuesCopy;
   });
 };
 
@@ -126,13 +112,7 @@ export default function ShoppingListsStore() {
   useProvideStore(storeId, store);
 
   // In turn 'render' (i.e. create) all of the shopping lists themselves.
-  return Object.entries(useTable("lists", storeId)).map(
-    ([listId, { initialContentJson }]) => (
-      <ShoppingListStore
-        listId={listId}
-        initialContentJson={initialContentJson}
-        key={listId}
-      />
-    )
-  );
+  return Object.entries(useTable("lists", storeId)).map(([listId]) => (
+    <ShoppingListStore listId={listId} key={listId} />
+  ));
 }

--- a/client/stores/ShoppingListsStore.tsx
+++ b/client/stores/ShoppingListsStore.tsx
@@ -23,6 +23,7 @@ const {
   useProvideStore,
   useRowIds,
   useSetCellCallback,
+  useSortedRowIds,
   useStore,
   useTable,
 } = UiReact as UiReact.WithSchemas<[typeof TABLES_SCHEMA, NoValuesSchema]>;
@@ -88,18 +89,15 @@ export const useDelShoppingListCallback = (id: string) =>
 // Returns the IDs of all shopping lists in the store.
 export const useShoppingListIds = () => useRowIds("lists", useStoreId());
 
-export const useRecentShoppingLists = () => {
-  const storeId = useStoreId();
-  const store = useStore(storeId);
-  const listIds = useRowIds("lists", storeId);
-
-  // Get up to 10 most recent lists
-  const recentListIds = listIds.slice(0, 10);
-
-  return recentListIds.map((listId) => {
-    return store.getRow("lists", listId)?.valuesCopy;
+// Returns the (copy of) values of all shopping lists in the store.
+export const useShoppingListsValues = () =>
+  Object.values(useTable("lists", useStoreId())).map(({ valuesCopy }) => {
+    try {
+      return JSON.parse(valuesCopy);
+    } catch {
+      return {};
+    }
   });
-};
 
 // Create, persist, and sync a store containing the IDs of the shopping lists.
 export default function ShoppingListsStore() {

--- a/client/stores/ShoppingListsStore.tsx
+++ b/client/stores/ShoppingListsStore.tsx
@@ -111,6 +111,10 @@ export default function ShoppingListsStore() {
 
   // In turn 'render' (i.e. create) all of the shopping lists themselves.
   return Object.entries(useTable("lists", storeId)).map(([listId]) => (
-    <ShoppingListStore listId={listId} key={listId} />
+    <ShoppingListStore
+      listId={listId}
+      key={listId}
+      useValuesCopy={useValuesCopy}
+    />
   ));
 }

--- a/client/stores/persistence/useCreateClientPersisterAndStart.ts
+++ b/client/stores/persistence/useCreateClientPersisterAndStart.ts
@@ -11,7 +11,7 @@ export const useCreateClientPersisterAndStart = <
 >(
   storeId: string,
   store: MergeableStore<Schemas>,
-  initialContentJson?: string,
+  initialValues?: string,
   then?: () => void
 ) =>
   (UiReact as UiReact.WithSchemas<Schemas>).useCreatePersister(
@@ -23,7 +23,7 @@ export const useCreateClientPersisterAndStart = <
       // Determine if there is initial content for a newly-created store.
       let initialContent: Content<Schemas> | undefined = undefined;
       try {
-        initialContent = JSON.parse(initialContentJson);
+        initialContent = [{}, JSON.parse(initialValues)];
       } catch {}
 
       // Start the persistence.
@@ -31,5 +31,5 @@ export const useCreateClientPersisterAndStart = <
       await persister.startAutoSave();
       then?.();
     },
-    [initialContentJson]
+    [initialValues]
   );


### PR DESCRIPTION
This maintains a mirror from the (source of truth) values in each 'list' store to the parent 'lists' store so that you can quickly extract all the metadata for widgets etc